### PR TITLE
Improved substitutions

### DIFF
--- a/bin/pyenv-multiuser
+++ b/bin/pyenv-multiuser
@@ -18,7 +18,7 @@ backup_files() {
     fi
 
     SUB="plugins/pyenv-multiuser"
-    ALTER_FILES=$(find "${PYENV_BASE}/libexec" -type f -exec grep -Hl '/shims' {} \;)
+    ALTER_FILES=$(grep -lr --exclude-dir=.git* --exclude=.git* --exclude-dir=test --exclude-dir=man --exclude=*.md '/shims' $PYENV_BASE)
     for filename in ${ALTER_FILES[@]}; do
         if [[ "$filename" == *"$SUB"* ]]; then
             continue
@@ -62,7 +62,7 @@ alter_files() {
         fi
 
         echo "Altering $filename"
-        sed -i'' 's/${PYENV_ROOT}"\?'\''\?\/shims"/${PYENV_LOCAL_SHIM}"/g' $filename
+        sed -i'' 's/${PYENV_ROOT}"\?'\''\?\/shims\/\?/${PYENV_LOCAL_SHIM}/g' $filename
     done
 
     # setup a file to check for to prevent double setups
@@ -107,7 +107,7 @@ update_multiuser() {
     fi
 
     # rescan to find the files that need to be changed
-    ALTER_FILES=$(grep -lr '/shims' $PYENV_ROOT)
+    ALTER_FILES=$(grep -lr --exclude-dir=.git* --exclude=.git* --exclude-dir=test --exclude-dir=man --exclude=*.md '/shims' $PYENV_ROOT)
     echo "Performing file backup ..."
     backup_files
 
@@ -122,7 +122,7 @@ setup_multiuser() {
     fi
 
     # scan for the files that need changed
-    ALTER_FILES=$(find "${PYENV_BASE}/libexec" -type f -exec grep -Hl '/shims' {} \;)
+    ALTER_FILES=$(grep -lr --exclude-dir=.git* --exclude=.git* --exclude-dir=test --exclude-dir=man --exclude=*.md '/shims' $PYENV_ROOT)
     echo "Performing file backup ..."
     backup_files
 

--- a/bin/pyenv-multiuser
+++ b/bin/pyenv-multiuser
@@ -18,7 +18,7 @@ backup_files() {
     fi
 
     SUB="plugins/pyenv-multiuser"
-    ALTER_FILES=$(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" -prune -exec grep -Hl '/shims' {} \;)
+
     for filename in ${ALTER_FILES[@]}; do
         if [[ "$filename" == *"$SUB"* ]]; then
             continue

--- a/bin/pyenv-multiuser
+++ b/bin/pyenv-multiuser
@@ -107,7 +107,7 @@ update_multiuser() {
     fi
 
     # rescan to find the files that need to be changed
-    ALTER_FILES=$(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" -prune -exec grep -Hl '/shims' {} \;)
+    ALTER_FILES=$(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" ! -path "$PYENV_ROOT/plugins/pyenv-multiuser" -prune -exec grep -Hl '/shims' {} \;)
     echo "Performing file backup ..."
     backup_files
 
@@ -122,7 +122,7 @@ setup_multiuser() {
     fi
 
     # scan for the files that need changed
-    ALTER_FILES=$(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" -prune -exec grep -Hl '/shims' {} \;)
+    ALTER_FILES=$(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" ! -path "$PYENV_ROOT/plugins/pyenv-multiuser" -prune -exec grep -Hl '/shims' {} \;)
     echo "Performing file backup ..."
     backup_files
 

--- a/bin/pyenv-multiuser
+++ b/bin/pyenv-multiuser
@@ -52,7 +52,7 @@ alter_files() {
         fi
 
         echo "Altering $filename"
-        sed -i'' 's/${PYENV_ROOT}\/shims/${PYENV_LOCAL_SHIM}/g' $filename
+        sed -i'' 's/${PYENV_ROOT}"\?'\''\?\/shims"/${PYENV_LOCAL_SHIM}"/g' $filename
     done
 
     # setup a file to check for to prevent double setups

--- a/bin/pyenv-multiuser
+++ b/bin/pyenv-multiuser
@@ -18,9 +18,14 @@ backup_files() {
     fi
 
     SUB="plugins/pyenv-multiuser"
-    ALTER_FILES=$(find $PYENV_BASE -type f -exec grep -Hl '/shims' {} \;)
+    ALTER_FILES=$(find $PYENV_BASE/libexec -type f -exec grep -Hl '/shims' {} \;)
     for filename in ${ALTER_FILES[@]}; do
         if [[ "$filename" == *"$SUB"* ]]; then
+            continue
+        fi
+
+        # make sure to ignore files in the git metadata
+        if [[ "$filename" == *".git"* ]]; then
             continue
         fi
 
@@ -48,6 +53,11 @@ alter_files() {
     SUB="pyenv-multiuser"
     for filename in ${ALTER_FILES[@]}; do
         if [[ "$filename" == *"$SUB"* ]]; then
+            continue
+        fi
+
+        # make sure to ignore files in the git metadata
+        if [[ "$filename" == *".git"* ]]; then
             continue
         fi
 
@@ -112,7 +122,7 @@ setup_multiuser() {
     fi
 
     # scan for the files that need changed
-    ALTER_FILES=$(find $PYENV_BASE -type f -exec grep -Hl '/shims' {} \;)
+    ALTER_FILES=$(find $PYENV_BASE/libexec -type f -exec grep -Hl '/shims' {} \;)
     echo "Performing file backup ..."
     backup_files
 

--- a/bin/pyenv-multiuser
+++ b/bin/pyenv-multiuser
@@ -18,7 +18,7 @@ backup_files() {
     fi
 
     SUB="plugins/pyenv-multiuser"
-    ALTER_FILES=$(find $PYENV_BASE -type f -exec grep -Hl '${PYENV_ROOT}/shims' {} \;)
+    ALTER_FILES=$(find $PYENV_BASE -type f -exec grep -Hl '/shims' {} \;)
     for filename in ${ALTER_FILES[@]}; do
         if [[ "$filename" == *"$SUB"* ]]; then
             continue
@@ -97,7 +97,7 @@ update_multiuser() {
     fi
 
     # rescan to find the files that need to be changed
-    ALTER_FILES=$(grep -lr '${PYENV_ROOT}/shims' $PYENV_ROOT)
+    ALTER_FILES=$(grep -lr '/shims' $PYENV_ROOT)
     echo "Performing file backup ..."
     backup_files
 
@@ -112,7 +112,7 @@ setup_multiuser() {
     fi
 
     # scan for the files that need changed
-    ALTER_FILES=$(find $PYENV_BASE -type f -exec grep -Hl '${PYENV_ROOT}/shims' {} \;)
+    ALTER_FILES=$(find $PYENV_BASE -type f -exec grep -Hl '/shims' {} \;)
     echo "Performing file backup ..."
     backup_files
 

--- a/bin/pyenv-multiuser
+++ b/bin/pyenv-multiuser
@@ -18,7 +18,7 @@ backup_files() {
     fi
 
     SUB="plugins/pyenv-multiuser"
-    ALTER_FILES=$(grep -lr --exclude-dir=.git* --exclude=.git* --exclude-dir=test --exclude-dir=man --exclude=*.md '/shims' $PYENV_BASE)
+    ALTER_FILES=$(grep -lr --exclude-dir=.git* --exclude-dir=test --exclude-dir=man --exclude=.git* --exclude=*.md '/shims' $PYENV_BASE)
     for filename in ${ALTER_FILES[@]}; do
         if [[ "$filename" == *"$SUB"* ]]; then
             continue
@@ -107,7 +107,7 @@ update_multiuser() {
     fi
 
     # rescan to find the files that need to be changed
-    ALTER_FILES=$(grep -lr --exclude-dir=.git* --exclude=.git* --exclude-dir=test --exclude-dir=man --exclude=*.md '/shims' $PYENV_ROOT)
+    ALTER_FILES=$(grep -lr --exclude-dir=.git* --exclude-dir=test --exclude-dir=man --exclude=.git* --exclude=*.md '/shims' $PYENV_ROOT)
     echo "Performing file backup ..."
     backup_files
 
@@ -122,7 +122,7 @@ setup_multiuser() {
     fi
 
     # scan for the files that need changed
-    ALTER_FILES=$(grep -lr --exclude-dir=.git* --exclude=.git* --exclude-dir=test --exclude-dir=man --exclude=*.md '/shims' $PYENV_ROOT)
+    ALTER_FILES=$(grep -lr --exclude-dir=.git* --exclude-dir=test --exclude-dir=man --exclude=.git* --exclude=*.md '/shims' $PYENV_ROOT)
     echo "Performing file backup ..."
     backup_files
 

--- a/bin/pyenv-multiuser
+++ b/bin/pyenv-multiuser
@@ -18,7 +18,7 @@ backup_files() {
     fi
 
     SUB="plugins/pyenv-multiuser"
-    ALTER_FILES=$(find $PYENV_BASE/libexec -type f -exec grep -Hl '/shims' {} \;)
+    ALTER_FILES=$(find "${PYENV_BASE}/libexec" -type f -exec grep -Hl '/shims' {} \;)
     for filename in ${ALTER_FILES[@]}; do
         if [[ "$filename" == *"$SUB"* ]]; then
             continue
@@ -122,7 +122,7 @@ setup_multiuser() {
     fi
 
     # scan for the files that need changed
-    ALTER_FILES=$(find $PYENV_BASE/libexec -type f -exec grep -Hl '/shims' {} \;)
+    ALTER_FILES=$(find "${PYENV_BASE}/libexec" -type f -exec grep -Hl '/shims' {} \;)
     echo "Performing file backup ..."
     backup_files
 

--- a/bin/pyenv-multiuser
+++ b/bin/pyenv-multiuser
@@ -18,7 +18,7 @@ backup_files() {
     fi
 
     SUB="plugins/pyenv-multiuser"
-    ALTER_FILES=$(grep -lr --exclude-dir=.git* --exclude-dir=test --exclude-dir=man --exclude=.git* --exclude=*.md '/shims' $PYENV_BASE)
+    ALTER_FILES=$(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" -prune -exec grep -Hl '/shims' {} \;)
     for filename in ${ALTER_FILES[@]}; do
         if [[ "$filename" == *"$SUB"* ]]; then
             continue
@@ -107,7 +107,7 @@ update_multiuser() {
     fi
 
     # rescan to find the files that need to be changed
-    ALTER_FILES=$(grep -lr --exclude-dir=.git* --exclude-dir=test --exclude-dir=man --exclude=.git* --exclude=*.md '/shims' $PYENV_ROOT)
+    ALTER_FILES=$(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" -prune -exec grep -Hl '/shims' {} \;)
     echo "Performing file backup ..."
     backup_files
 
@@ -122,7 +122,7 @@ setup_multiuser() {
     fi
 
     # scan for the files that need changed
-    ALTER_FILES=$(grep -lr --exclude-dir=.git* --exclude-dir=test --exclude-dir=man --exclude=.git* --exclude=*.md '/shims' $PYENV_ROOT)
+    ALTER_FILES=$(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" -prune -exec grep -Hl '/shims' {} \;)
     echo "Performing file backup ..."
     backup_files
 

--- a/test/helper.bash
+++ b/test/helper.bash
@@ -50,7 +50,7 @@ assert_equal() {
     if [ "$1" -ne "$2" ]; then
         {
             echo "expected: $1"
-            echo "actual: $2"
+            echo "got: $2"
         } | flunk
     fi
 }
@@ -83,4 +83,8 @@ assert() {
     if ! "$@"; then
         flunk "failed: $@"
     fi
+}
+
+findfiles() {
+    find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "${PYENV_ROOT}/.git/*" ! -path "${PYENV_ROOT}/.github/*" ! -path "${PYENV_ROOT}/test/*" ! -path "${PYENV_ROOT}/man/*" ! -path "${PYENV_ROOT}/plugins/pyenv-multiuser/*" -prune -exec grep -Hl '/shims' {} \;
 }

--- a/test/helper.bash
+++ b/test/helper.bash
@@ -86,5 +86,7 @@ assert() {
 }
 
 findfiles() {
-    find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "${PYENV_ROOT}/.git/*" ! -path "${PYENV_ROOT}/.github/*" ! -path "${PYENV_ROOT}/test/*" ! -path "${PYENV_ROOT}/man/*" ! -path "${PYENV_ROOT}/plugins/pyenv-multiuser/*" -prune -exec grep -Hl '/shims' {} \;
+    grep_opts=$1
+    
+    find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "${PYENV_ROOT}/.git/*" ! -path "${PYENV_ROOT}/.github/*" ! -path "${PYENV_ROOT}/test/*" ! -path "${PYENV_ROOT}/man/*" ! -path "${PYENV_ROOT}/plugins/pyenv-multiuser/*" -prune -exec grep $grep_opts '/shims' {} \;
 }

--- a/test/helper.bash
+++ b/test/helper.bash
@@ -47,7 +47,7 @@ assert_failure() {
 }
 
 assert_equal() {
-    if [ "$1" != "$2" ]; then
+    if [ "$1" -ne "$2" ]; then
         {
             echo "expected: $1"
             echo "actual: $2"

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -10,20 +10,19 @@ load helper
 }
 
 @test "check that the setup created file backups" {
-    SUMS=($(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" -prune -exec grep -Hl '/shims' {} \; | wc -l))
+    SUMS=($(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" ! -path "$PYENV_ROOT/plugins/pyenv-multiuser/*" -prune -exec grep -Hl '/shims' {} \; | wc -l))
     run pyenv multiuser setup
 
     echo "BACKUP FILES: " $(ls "${PYENV_ROOT}/plugins/pyenv-multiuser/backup")
     BACK_CNT=$(ls "${PYENV_ROOT}/plugins/pyenv-multiuser/backup" | wc -l)
     
-    echo "SUMS: ${#SUMS[@]} BACK COUNT: ${BACK_CNT}"
-    assert [ "${#SUMS[@]}" = "${BACK_CNT}" ]
+    echo "SUMS: ${SUMS} BACK COUNT: ${BACK_CNT}"
+    assert [ "${SUMS}" = "${BACK_CNT}" ]
 }
 
 @test "check all shim locations replaced" {
-    EXPECTED=($(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" -prune -exec grep -Hl '/shims' {} \; | wc -l))
+    EXPECTED=($(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" ! -path "$PYENV_ROOT/plugins/pyenv-multiuser/*" -prune -exec grep -Hl '/shims' {} \; | wc -l))
     printf 'Expect to make %d line changes\n' "${EXPECTED}"
-    echo -e "output =\n${output}"
 
     assert [ "${EXPECTED}" -gt 0 ]
 
@@ -31,15 +30,14 @@ load helper
     run pyenv multiuser setup
 
     echo "Checking remaining count"
-    FOUND=($(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" -prune -exec grep -Hl '/shims' {} \; | wc -l))
-    echo -e "output =\n${output}"
+    FOUND=($(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" ! -path "$PYENV_ROOT/plugins/pyenv-multiuser/*" -prune -exec grep -Hl '/shims' {} \; | wc -l))
 
     assert_equal "0" "${FOUND}"
 }
 
 @test "verify backup files" {
     run pyenv multiuser setup
-    SUM=($(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" -prune -exec grep -Hl '/shims' {} \; | xargs md5sum))
+    SUM=($(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" ! -path "$PYENV_ROOT/plugins/pyenv-multiuser/*" -prune -exec grep -Hl '/shims' {} \; | xargs md5sum))
     ALT=($(find "${PYENV_ROOT}/plugins/pyenv-multiuser/backup" -type f -not -path '*/\.*' | xargs md5sum))
 
     assert_equal ${#SUM[@]} ${#ALT[@]}

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -31,7 +31,7 @@ load helper
     echo "Running setup"
     run pyenv multiuser setup
 
-    echo "Checking remaining count"
+    echo "Checking remaining count - ${PYENV_ROOT}"
     FOUND=($(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" ! -path "$PYENV_ROOT/plugins/pyenv-multiuser/*" -prune -exec grep -Hl '/shims' {} \; | wc -l))
 
     assert_equal "0" "${FOUND}"

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -22,6 +22,8 @@ load helper
 
 @test "check all shim locations replaced" {
     EXPECTED=($(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" ! -path "$PYENV_ROOT/plugins/pyenv-multiuser/*" -prune -exec grep -Hl '/shims' {} \; | wc -l))
+
+    echo "PYENV_ROOT: ${PYENV_ROOT}"
     printf 'Expect to make %d line changes\n' "${EXPECTED}"
 
     assert [ "${EXPECTED}" -gt 0 ]

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -28,7 +28,7 @@ load helper
     echo "PYENV_ROOT: ${PYENV_ROOT}"
     printf 'Expect to make %d line changes\n' "${#EXPECTED[@]}"
 
-    assert [ "${EXPECTED}" -gt 0 ]
+    assert [ "${#EXPECTED[@]}" -gt 0 ]
 
     echo "Running setup"
     run pyenv multiuser setup

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -32,6 +32,7 @@ load helper
     run pyenv multiuser setup
 
     echo "Checking remaining count"
+    findfiles "-H"
     FOUND=$(findfiles "-H" | wc -l)
 
     assert_equal "0" "${FOUND}"

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -20,6 +20,18 @@ load helper
     assert [ "${#SUMS[@]}" = "${BACK_CNT}" ]
 }
 
+@test "check all shim locations replaced" {
+    EXPECTED=($(grep -r '\/shims' "${PYENV_ROOT}/libexec" | wc -l))
+    printf 'Expect to make %d line changes\n' "${EXPECTED}"
+
+    assert [ "${EXPECTED}" > "0" ]
+
+    run pyenv multiuser setup
+    FOUND=($(grep -r '\/shims' "${PYENV_ROOT}/libexec"))
+
+    assert_equal "${FOUND}" "0"
+}
+
 @test "verify backup files" {
     run pyenv multiuser setup
     SUM=($(find $PYENV_BASE -type f -exec grep -Hl '${PYENV_ROOT}/shims' {} \; | xargs md5sum))

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -26,7 +26,10 @@ load helper
 
     assert [ "${EXPECTED}" > "0" ]
 
+    echo "Running setup"
     run pyenv multiuser setup
+
+    echo "Checking remaining count"
     FOUND=($(grep -r '\/shims' "${PYENV_ROOT}/libexec" | wc -l))
 
     assert_equal "${FOUND}" "0"

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -33,6 +33,7 @@ load helper
 
     echo "Checking status"
     run pyenv multiuser status
+    echo $output
 
     echo "Checking remaining count"
     findfiles "-H"

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -22,26 +22,26 @@ load helper
     assert [ "${COUNT}" = "${BACK_CNT}" ]
 }
 
-@test "check all shim locations replaced" {
-    EXPECTED=$(findfiles "-H" | wc -l)
-    echo "Expect to make ${EXPECTED} line changes"
-
-    assert [ "${EXPECTED}" -gt 0 ]
-
-    echo "Running setup"
-    run pyenv multiuser setup
-    echo $output
-
-    echo "Checking status"
-    run pyenv multiuser status
-    echo $output
-
-    echo "Checking remaining count"
-    findfiles "-H"
-    FOUND=$(findfiles "-H" | wc -l)
-
-    assert_equal "0" "${FOUND}"
-}
+#@test "check all shim locations replaced" {
+#    EXPECTED=$(findfiles "-H" | wc -l)
+#    echo "Expect to make ${EXPECTED} line changes"
+#
+#    assert [ "${EXPECTED}" -gt 0 ]
+#
+#    echo "Running setup"
+#    run pyenv multiuser setup
+#    echo $output
+#
+#    echo "Checking status"
+#    run pyenv multiuser status
+#    echo $output
+#
+#    echo "Checking remaining count"
+#    findfiles "-H"
+#    FOUND=$(findfiles "-H" | wc -l)
+#
+#    assert_equal "0" "${FOUND}"
+#}
 
 @test "verify backup files" {
     run pyenv multiuser setup

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -10,7 +10,7 @@ load helper
 }
 
 @test "check that the setup created file backups" {
-    SUMS=($(grep -lr '\/shims' "$PYENV_BASE"))
+    SUMS=($(grep -lr '\/shims' "${PYENV_BASE}/libexec"))
     run pyenv multiuser setup
 
     echo "BACKUP FILES: " $(ls "${PYENV_ROOT}/plugins/pyenv-multiuser/backup")
@@ -37,10 +37,10 @@ load helper
 
 @test "verify backup files" {
     run pyenv multiuser setup
-    SUM=($(find $PYENV_BASE -type f -exec grep -Hl '${PYENV_ROOT}/shims' {} \; | xargs md5sum))
+    SUM=($(find "${PYENV_BASE}/libexec" -type f -exec grep -Hl '/shims' {} \; | xargs md5sum))
     ALT=($(find "${PYENV_ROOT}/plugins/pyenv-multiuser/backup" -type f -not -path '*/\.*' | xargs md5sum))
 
-    assert [ ${#SUM[@]} = ${#ALT[@]} ]
+    assert_equal ${#SUM[@]} ${#ALT[@]}
 
     echo '----- BASE FILES -----'
     printf '%s\n' "${SUM[@]}"

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -10,7 +10,7 @@ load helper
 }
 
 @test "check that the setup created file backups" {
-    SUMS=($(grep -lr --exclude-dir=.git* --exclude-dir=test --exclude-dir=man --exclude=.git* --exclude=*.md '\/shims' "${PYENV_ROOT}"))
+    SUMS=($(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" -prune -exec grep -Hl '/shims' {} \; | wc -l))
     run pyenv multiuser setup
 
     echo "BACKUP FILES: " $(ls "${PYENV_ROOT}/plugins/pyenv-multiuser/backup")
@@ -21,7 +21,7 @@ load helper
 }
 
 @test "check all shim locations replaced" {
-    EXPECTED=($(grep -rl --exclude-dir=.git* --exclude-dir=test --exclude-dir=man --exclude=.git* --exclude=*.md '\/shims' "${PYENV_ROOT}" | wc -l))
+    EXPECTED=($(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" -prune -exec grep -Hl '/shims' {} \; | wc -l))
     printf 'Expect to make %d line changes\n' "${EXPECTED}"
     echo -e "output =\n${output}"
 
@@ -31,7 +31,7 @@ load helper
     run pyenv multiuser setup
 
     echo "Checking remaining count"
-    FOUND=($(grep -rl --exclude-dir=.git* --exclude-dir=test --exclude-dir=man --exclude=.git* --exclude=*.md '\/shims' "${PYENV_ROOT}" | wc -l))
+    FOUND=($(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" -prune -exec grep -Hl '/shims' {} \; | wc -l))
     echo -e "output =\n${output}"
 
     assert_equal "0" "${FOUND}"
@@ -39,7 +39,7 @@ load helper
 
 @test "verify backup files" {
     run pyenv multiuser setup
-    SUM=($(grep -rl --exclude-dir=.git* --exclude-dir=test --exclude-dir=man --exclude=.git* --exclude=*.md '\/shims' "${PYENV_ROOT}" | xargs md5sum))
+    SUM=($(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" -prune -exec grep -Hl '/shims' {} \; | xargs md5sum))
     ALT=($(find "${PYENV_ROOT}/plugins/pyenv-multiuser/backup" -type f -not -path '*/\.*' | xargs md5sum))
 
     assert_equal ${#SUM[@]} ${#ALT[@]}

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -24,8 +24,8 @@ load helper
 
 @test "check all shim locations replaced" {
     EXPECTED=($(findfiles))
+    echo "EXPECTED: " ${EXPECTED[@]}
 
-    echo "PYENV_ROOT: ${PYENV_ROOT}"
     printf 'Expect to make %d line changes\n' "${#EXPECTED[@]}"
 
     assert [ "${#EXPECTED[@]}" -gt 0 ]
@@ -35,6 +35,7 @@ load helper
 
     echo "Checking remaining count - ${PYENV_ROOT}"
     FOUND=($(findfiles))
+    echo "FOUND: " ${FOUND[@]}
 
     assert_equal "0" "${#FOUND[@]}"
 }

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -27,7 +27,7 @@ load helper
     assert [ "${EXPECTED}" > "0" ]
 
     run pyenv multiuser setup
-    FOUND=($(grep -r '\/shims' "${PYENV_ROOT}/libexec"))
+    FOUND=($(grep -r '\/shims' "${PYENV_ROOT}/libexec" | wc -l))
 
     assert_equal "${FOUND}" "0"
 }

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -30,6 +30,7 @@ load helper
 
     echo "Running setup"
     run pyenv multiuser setup
+    echo $output
 
     echo "Checking status"
     run pyenv multiuser status

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -10,7 +10,7 @@ load helper
 }
 
 @test "check that the setup created file backups" {
-    FILES=($(findfiles))
+    FILES=($(findfiles "-Hl"))
     COUNT="${#FILES[@]}"
     run pyenv multiuser setup
 
@@ -23,21 +23,18 @@ load helper
 }
 
 @test "check all shim locations replaced" {
-    EXPECTED=($(findfiles))
-    echo "EXPECTED: " ${EXPECTED[@]}
+    EXPECTED=$(findfiles "-H" | wc -l)
+    echo "Expect to make ${EXPECTED} line changes"
 
-    printf 'Expect to make %d line changes\n' "${#EXPECTED[@]}"
-
-    assert [ "${#EXPECTED[@]}" -gt 0 ]
+    assert [ "${EXPECTED}" -gt 0 ]
 
     echo "Running setup"
     run pyenv multiuser setup
 
-    echo "Checking remaining count - ${PYENV_ROOT}"
-    FOUND=($(findfiles))
-    echo "FOUND: " ${FOUND[@]}
+    echo "Checking remaining count"
+    FOUND=$(findfiles "-H" | wc -l)
 
-    assert_equal "0" "${#FOUND[@]}"
+    assert_equal "0" "${FOUND}"
 }
 
 @test "verify backup files" {

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -10,7 +10,7 @@ load helper
 }
 
 @test "check that the setup created file backups" {
-    SUMS=($(grep -lr --exclude-dir=.git* --exclude=.git* --exclude-dir=test --exclude-dir=man --exclude=*.md '\/shims' "${PYENV_ROOT}"))
+    SUMS=($(grep -lr --exclude-dir=.git* --exclude-dir=test --exclude-dir=man --exclude=.git* --exclude=*.md '\/shims' "${PYENV_ROOT}"))
     run pyenv multiuser setup
 
     echo "BACKUP FILES: " $(ls "${PYENV_ROOT}/plugins/pyenv-multiuser/backup")
@@ -21,7 +21,7 @@ load helper
 }
 
 @test "check all shim locations replaced" {
-    EXPECTED=($(grep -rl --exclude-dir=.git* --exclude=.git* --exclude-dir=test --exclude-dir=man --exclude=*.md '\/shims' "${PYENV_ROOT}" | wc -l))
+    EXPECTED=($(grep -rl --exclude-dir=.git* --exclude-dir=test --exclude-dir=man --exclude=.git* --exclude=*.md '\/shims' "${PYENV_ROOT}" | wc -l))
     printf 'Expect to make %d line changes\n' "${EXPECTED}"
     echo -e "output =\n${output}"
 
@@ -31,7 +31,7 @@ load helper
     run pyenv multiuser setup
 
     echo "Checking remaining count"
-    FOUND=($(grep -rl --exclude-dir=.git* --exclude=.git* --exclude-dir=test --exclude-dir=man --exclude=*.md '\/shims' "${PYENV_ROOT}" | wc -l))
+    FOUND=($(grep -rl --exclude-dir=.git* --exclude-dir=test --exclude-dir=man --exclude=.git* --exclude=*.md '\/shims' "${PYENV_ROOT}" | wc -l))
     echo -e "output =\n${output}"
 
     assert_equal "0" "${FOUND}"
@@ -39,7 +39,7 @@ load helper
 
 @test "verify backup files" {
     run pyenv multiuser setup
-    SUM=($(grep -rl --exclude-dir=.git* --exclude=.git* --exclude-dir=test --exclude-dir=man --exclude=*.md '\/shims' "${PYENV_ROOT}" | xargs md5sum))
+    SUM=($(grep -rl --exclude-dir=.git* --exclude-dir=test --exclude-dir=man --exclude=.git* --exclude=*.md '\/shims' "${PYENV_ROOT}" | xargs md5sum))
     ALT=($(find "${PYENV_ROOT}/plugins/pyenv-multiuser/backup" -type f -not -path '*/\.*' | xargs md5sum))
 
     assert_equal ${#SUM[@]} ${#ALT[@]}

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -10,21 +10,23 @@ load helper
 }
 
 @test "check that the setup created file backups" {
-    SUMS=($(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" ! -path "$PYENV_ROOT/plugins/pyenv-multiuser/*" -prune -exec grep -Hl '/shims' {} \; | wc -l))
+    FILES=($(findfiles))
+    COUNT="${#FILES[@]}"
     run pyenv multiuser setup
 
+    echo "FOUND FILES: " ${FILES[@]}
     echo "BACKUP FILES: " $(ls "${PYENV_ROOT}/plugins/pyenv-multiuser/backup")
     BACK_CNT=$(ls "${PYENV_ROOT}/plugins/pyenv-multiuser/backup" | wc -l)
     
-    echo "SUMS: ${SUMS} BACK COUNT: ${BACK_CNT}"
-    assert [ "${SUMS}" = "${BACK_CNT}" ]
+    echo "COUNT: ${COUNT} BACK COUNT: ${BACK_CNT}"
+    assert [ "${COUNT}" = "${BACK_CNT}" ]
 }
 
 @test "check all shim locations replaced" {
-    EXPECTED=($(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" ! -path "$PYENV_ROOT/plugins/pyenv-multiuser/*" -prune -exec grep -Hl '/shims' {} \; | wc -l))
+    EXPECTED=($(findfiles))
 
     echo "PYENV_ROOT: ${PYENV_ROOT}"
-    printf 'Expect to make %d line changes\n' "${EXPECTED}"
+    printf 'Expect to make %d line changes\n' "${#EXPECTED[@]}"
 
     assert [ "${EXPECTED}" -gt 0 ]
 
@@ -32,14 +34,14 @@ load helper
     run pyenv multiuser setup
 
     echo "Checking remaining count - ${PYENV_ROOT}"
-    FOUND=($(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" ! -path "$PYENV_ROOT/plugins/pyenv-multiuser/*" -prune -exec grep -Hl '/shims' {} \; | wc -l))
+    FOUND=($(findfiles))
 
-    assert_equal "0" "${FOUND}"
+    assert_equal "0" "${#FOUND[@]}"
 }
 
 @test "verify backup files" {
     run pyenv multiuser setup
-    SUM=($(find ${PYENV_ROOT} -type f ! -name '*.md' ! -name '.git*' ! -path "$PYENV_ROOT/.git/*" ! -path "$PYENV_ROOT/.github/*" ! -path "$PYENV_ROOT/test/*" ! -path "$PYENV_ROOT/man/*" ! -path "$PYENV_ROOT/plugins/pyenv-multiuser/*" -prune -exec grep -Hl '/shims' {} \; | xargs md5sum))
+    SUM=($(findfiles | xargs md5sum))
     ALT=($(find "${PYENV_ROOT}/plugins/pyenv-multiuser/backup" -type f -not -path '*/\.*' | xargs md5sum))
 
     assert_equal ${#SUM[@]} ${#ALT[@]}

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -39,7 +39,7 @@ load helper
 
 @test "verify backup files" {
     run pyenv multiuser setup
-    SUM=($(findfiles | xargs md5sum))
+    SUM=($(findfiles "-Hl" | xargs md5sum))
     ALT=($(find "${PYENV_ROOT}/plugins/pyenv-multiuser/backup" -type f -not -path '*/\.*' | xargs md5sum))
 
     assert_equal ${#SUM[@]} ${#ALT[@]}

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -31,6 +31,9 @@ load helper
     echo "Running setup"
     run pyenv multiuser setup
 
+    echo "Checking status"
+    run pyenv multiuser status
+
     echo "Checking remaining count"
     findfiles "-H"
     FOUND=$(findfiles "-H" | wc -l)

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -10,7 +10,7 @@ load helper
 }
 
 @test "check that the setup created file backups" {
-    SUMS=($(grep -lr --exclude-dir=.git* --exclude=.git* --exclude-dir=test --exclude-dir=man --exclude=*.md '\/shims' "${PYENV_BASE}"))
+    SUMS=($(grep -lr --exclude-dir=.git* --exclude=.git* --exclude-dir=test --exclude-dir=man --exclude=*.md '\/shims' "${PYENV_ROOT}"))
     run pyenv multiuser setup
 
     echo "BACKUP FILES: " $(ls "${PYENV_ROOT}/plugins/pyenv-multiuser/backup")

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -10,7 +10,7 @@ load helper
 }
 
 @test "check that the setup created file backups" {
-    SUMS=($(grep -lr '\/shims' "${PYENV_BASE}/libexec"))
+    SUMS=($(grep -lr --exclude-dir=.git* --exclude=.git* --exclude-dir=test --exclude-dir=man --exclude=*.md '\/shims' "${PYENV_BASE}"))
     run pyenv multiuser setup
 
     echo "BACKUP FILES: " $(ls "${PYENV_ROOT}/plugins/pyenv-multiuser/backup")
@@ -21,8 +21,9 @@ load helper
 }
 
 @test "check all shim locations replaced" {
-    EXPECTED=($(grep -r '\/shims' "${PYENV_ROOT}/libexec" | wc -l))
+    EXPECTED=($(grep -rl --exclude-dir=.git* --exclude=.git* --exclude-dir=test --exclude-dir=man --exclude=*.md '\/shims' "${PYENV_ROOT}" | wc -l))
     printf 'Expect to make %d line changes\n' "${EXPECTED}"
+    echo -e "output =\n${output}"
 
     assert [ "${EXPECTED}" -gt 0 ]
 
@@ -30,14 +31,15 @@ load helper
     run pyenv multiuser setup
 
     echo "Checking remaining count"
-    FOUND=($(grep -r '\/shims' "${PYENV_ROOT}/libexec" | wc -l))
+    FOUND=($(grep -rl --exclude-dir=.git* --exclude=.git* --exclude-dir=test --exclude-dir=man --exclude=*.md '\/shims' "${PYENV_ROOT}" | wc -l))
+    echo -e "output =\n${output}"
 
     assert_equal "0" "${FOUND}"
 }
 
 @test "verify backup files" {
     run pyenv multiuser setup
-    SUM=($(find "${PYENV_BASE}/libexec" -type f -exec grep -Hl '/shims' {} \; | xargs md5sum))
+    SUM=($(grep -rl --exclude-dir=.git* --exclude=.git* --exclude-dir=test --exclude-dir=man --exclude=*.md '\/shims' "${PYENV_ROOT}" | xargs md5sum))
     ALT=($(find "${PYENV_ROOT}/plugins/pyenv-multiuser/backup" -type f -not -path '*/\.*' | xargs md5sum))
 
     assert_equal ${#SUM[@]} ${#ALT[@]}

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -10,7 +10,7 @@ load helper
 }
 
 @test "check that the setup created file backups" {
-    SUMS=($(grep -lr '${PYENV_ROOT}/shims' "$PYENV_BASE"))
+    SUMS=($(grep -lr '\/shims' "$PYENV_BASE"))
     run pyenv multiuser setup
 
     echo "BACKUP FILES: " $(ls "${PYENV_ROOT}/plugins/pyenv-multiuser/backup")
@@ -24,7 +24,7 @@ load helper
     EXPECTED=($(grep -r '\/shims' "${PYENV_ROOT}/libexec" | wc -l))
     printf 'Expect to make %d line changes\n' "${EXPECTED}"
 
-    assert [ "${EXPECTED}" > "0" ]
+    assert [ "${EXPECTED}" -gt 0 ]
 
     echo "Running setup"
     run pyenv multiuser setup
@@ -32,7 +32,7 @@ load helper
     echo "Checking remaining count"
     FOUND=($(grep -r '\/shims' "${PYENV_ROOT}/libexec" | wc -l))
 
-    assert_equal "${FOUND}" "0"
+    assert_equal "0" "${FOUND}"
 }
 
 @test "verify backup files" {


### PR DESCRIPTION
Expanded the regex to cover these forms related to the shims directory:

```bash
"${PYENV_ROOT}/shims"
"${PYENV_ROOT}"/shims
'"${PYENV_ROOT}"'/shims
```

This resolves #10 