### PR TITLE
fix-up sed regex to include trailing single and double quotes in replace

### DIFF
--- a/bin/pyenv-multiuser
+++ b/bin/pyenv-multiuser
@@ -62,7 +62,7 @@ alter_files() {
         fi
 
         echo "Altering $filename"
-        sed -i'' 's/${PYENV_ROOT}"\?'\''\?\/shims\/\?/${PYENV_LOCAL_SHIM}/g' $filename
+        sed -ri'' 's/${PYENV_ROOT}\(["'\'']*\?\)\(\/shims\/\?\)\?/${PYENV_LOCAL_SHIM}\1/g' $filename
     done
 
     # setup a file to check for to prevent double setups


### PR DESCRIPTION
- add in capture groups for use in replace
- zero or one the "/shims/" path